### PR TITLE
Disable suspend capability

### DIFF
--- a/fusion-make-bootcamp
+++ b/fusion-make-bootcamp
@@ -81,6 +81,7 @@ ehci:0.parent = "-1"
 ehci:0.port = "0"
 ehci:0.deviceType = "video"
 ehci:0.present = "TRUE"
+suspend.disabled = "TRUE"
 EOF
 }
 


### PR DESCRIPTION
Suspend is disabled for bootcamp guests by default when created using
VMware Fusion. It should be disabled to prevent corruption in case of
resuming the VM after booting using bootcamp.