### PR TITLE
Added BitLocker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ Using this script should let you create a Boot Camp VM.
     ```
 
 4. There should now be a Boot Camp VM on your desktop
+
+## BitLocker
+
+If you enable BitLocker after creating the VM, Fusion might say it can't find it anymore. 
+Just run the script again.

--- a/fusion-make-bootcamp
+++ b/fusion-make-bootcamp
@@ -90,6 +90,7 @@ diskutil_output=$(diskutil list "${target_disk}")
 vmdir=$(mktemp -d ~/Desktop/Boot\ Camp.XXXXXX)
 efi_id=$(echo "${diskutil_output}" | grep EFI | awk '{ print $1 }' | tr -d ':')
 bootcamp_id=$(echo "${diskutil_output}" | grep BOOTCAMP | awk '{ print $1 }' | tr -d ':')
+[ -z "${bootcamp_id}" ] && bootcamp_id=$(echo "${diskutil_output}" | grep 'Microsoft Basic Data' | awk '{ print $1 }' | tr -d ':')
 
 [ -z "${efi_id}" ] && die "Could not find EFI partition"
 [ -z "${bootcamp_id}" ] && die "Could not find Boot Camp partition"


### PR DESCRIPTION
Hi!

I just used your script to create my Bootcamp VM, but after enabling BitLocker it couldn't find the Bootcamp partition anymore.
Seems like OSX sees it as 'Microsoft Basic Data' (The BOOTCAMP label is gone):
```
└> diskutil list /dev/disk0
/dev/disk0 (internal):
   #:                       TYPE NAME                    SIZE       IDENTIFIER
   0:      GUID_partition_scheme                         500.3 GB   disk0
   1:                        EFI EFI                     314.6 MB   disk0s1
   2:          Apple_CoreStorage Macintosh HD            249.4 GB   disk0s2
   3:                 Apple_Boot Recovery HD             650.0 MB   disk0s3
   4:       Microsoft Basic Data                         250.0 GB   disk0s4
```

So I added a fallback in the script for this.

Thanks a lot for the code! It really helped me :)
Ohad